### PR TITLE
src/providers: fix dropped test errors

### DIFF
--- a/src/providers/git_test.go
+++ b/src/providers/git_test.go
@@ -281,6 +281,9 @@ func TestGetBlobReader(t *testing.T) {
 		t.Error(err)
 	}
 	content, err := ioutil.ReadAll(reader.(io.Reader))
+	if err != nil {
+		t.Error(err)
+	}
 	reader.(io.Closer).Close()
 	if !bytes.Contains(content, []byte("module github.com")) {
 		t.Error()
@@ -291,6 +294,9 @@ func TestGetBlobReader(t *testing.T) {
 		t.Error(err)
 	}
 	content, err = ioutil.ReadAll(reader.(io.Reader))
+	if err != nil {
+		t.Error(err)
+	}
 	reader.(io.Closer).Close()
 	if !bytes.Contains(content, []byte("module github.com")) {
 		t.Error()


### PR DESCRIPTION
This fixes two dropped test errors in `src/providers`.